### PR TITLE
Server API changes

### DIFF
--- a/KeyServer/KeyServer.yaml
+++ b/KeyServer/KeyServer.yaml
@@ -47,6 +47,9 @@ paths:
                     description: A newly-generated token
                     schema:
                         type: object
+                        required:
+                            - status
+                            - token
                         properties:
                             status:
                                 type: string
@@ -56,6 +59,15 @@ paths:
                                 type: string
                                 example: "SOME_TOKEN_DATA"
                                 description: This can be in whatever format is necessary for your system
+                            expires_at:
+                                type: string
+                                format: date-time
+                                description: |
+                                    This indicates when the token will definitely no longer work, meaning the client
+                                    can simply request a new one without needing determine it's invalidated. Server
+                                    can choose expiry time, and it can expire the token prematurely if necessary. If expired
+                                    prematurely, client will receive a 401 and request a new token.
+
                 401:
                     description: Unable to authorize user.
             
@@ -84,6 +96,10 @@ paths:
                     description: A list of infected keys since the specified date.
                     schema:
                         type: object
+                        required:
+                            - status
+                            - date
+                            - keys
                         properties:
                             status:
                                 type: string
@@ -135,9 +151,13 @@ paths:
                               description: List of infected keys
                               minimum: 1
                               items:
-                                  type: string
-                                  example: "Base 64 Encoded String"
-                                  description: Base 64 encoded binary data representing a single key
+                                  type: object
+                                  description: Contains information about a single key
+                                  properties:
+                                      d:
+                                        type: string
+                                        example: "Base 64 Encoded String"
+                                        description: Base 64 encoded binary data representing a single key
                           identifier:
                               type: string
                               description: An optional unique identifier from a previous submission so newly-submitted keys can be appended to an existing submission.
@@ -146,6 +166,8 @@ paths:
                     description: A list of infected keys since the specified date.
                     schema:
                         type: object
+                        required:
+                            - status
                         properties:
                             status:
                                 type: string

--- a/KeyServer/sample/htdocs/submit.php
+++ b/KeyServer/sample/htdocs/submit.php
@@ -46,7 +46,10 @@ if (count($keys) > 0) {
 
     $stmt = $db->prepare('INSERT INTO infected_keys (infected_key, timestamp, status, status_updated, submission_id) VALUES (:k, :t, :s, :d, :i)');
 
-    foreach ($json['keys'] as $encodedKey) {
+    foreach ($json['keys'] as $key) {
+	$encodedKey = $key['d']; // TODO: Validate the $key array
+	// TODO: Handle the rolling start number once we know more about how it works
+
         $stmt->bindValue(':k', $encodedKey, SQLITE3_TEXT);
         $stmt->bindValue(':t', $time, SQLITE3_INTEGER);
 	$stmt->bindValue(':s', 'P', SQLITE3_TEXT); // Pending state, must be approved


### PR DESCRIPTION
Add support for expires_at (#29 and #46); breaking change to key submission: each key element is now an object instead of a string. This is so additional data can be included with each key if necessary.